### PR TITLE
fix(ci): add SSH passphrase support for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          passphrase: ${{ secrets.VPS_SSH_PASSPHRASE }}
           port: ${{ secrets.VPS_PORT }}
           script: |
             cd ~/portfolio


### PR DESCRIPTION
## Summary

- Added `passphrase` input to the SSH deploy step using `${{ secrets.VPS_SSH_PASSPHRASE }}`
- Fixes authentication failure when the private key stored in `VPS_SSH_KEY` is passphrase-protected

## Required action

Add a new repository secret **`VPS_SSH_PASSPHRASE`** with the passphrase for your SSH private key.  
Alternatively, replace the key with a passphrase-free one generated specifically for CI (recommended).

## Test plan

- [ ] Add `VPS_SSH_PASSPHRASE` secret in GitHub → Settings → Secrets and variables → Actions
- [ ] Push to `master` and confirm the deploy workflow completes successfully
- [ ] Verify the site is live at `janikhawk.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)